### PR TITLE
Fix for the Wire.begin() call, it is not allowed.

### DIFF
--- a/VEML6075.cpp
+++ b/VEML6075.cpp
@@ -24,7 +24,6 @@ VEML6075::VEML6075() {
 
 bool VEML6075::begin() {
 
-  Wire.begin();
   if (this->getDevID() != VEML6075_DEVID) {
     return false;
   }


### PR DESCRIPTION
#2 the Wire.begin() call is not allowed within a library.