### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 # Class
 #######################################
 
-VEML6075		KEYWORD1
+VEML6075	KEYWORD1
 
 #######################################
 # Methods
 #######################################
 
-getUVA		KEYWORD2
-getUVB		KEYWORD2
-getUVDummy		KEYWORD2
-getUVcomp1		KEYWORD2
-getUVcomp2		KEYWORD2
-getDevID		KEYWORD2
+getUVA	KEYWORD2
+getUVB	KEYWORD2
+getUVDummy	KEYWORD2
+getUVcomp1	KEYWORD2
+getUVcomp2	KEYWORD2
+getDevID	KEYWORD2
 
 #######################################
 # Constants


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords